### PR TITLE
handle non provided entries

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -25,7 +25,7 @@ export default (opts = {}) => {
     }
   }
 
-  const fileChanged = ({url, entries}) => {
+  const fileChanged = ({url, entries={}}) => {
     d('reloading', url)
     System.reload(SystemJS.baseURL + url, {entries: [...entries, ...options.entries]})
   }


### PR DESCRIPTION
Current implementation fails, if no entries are provided. 

This fix has been tested against systemjs-hmr@2.0.8.